### PR TITLE
Implemented #8. Both @deprecated(reason: String), or an empty @deprec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,27 @@ SchemaParser.newParser()
 
 ### GraphQL Descriptions
 
-GraphQL object/field/argument descriptions can be provided by the `@doc` decorator, and are added to the generated schema:
+GraphQL object/field/argument descriptions can be provided by the `@doc` directive, and are added to the generated schema:
 
 ```graphql
 enum Episode @doc(d: "One of the films in the Star Wars Trilogy") {
     NEWHOPE @doc(d: "Released in 1977"),
     EMPIRE @doc(d: "Released in 1980"),
     JEDI @doc(d: "Released in 1983")
+}
+```
+### GraphQL Deprecations
+
+GraphQL field/enum deprecations can be provided by the `@deprecated(reason: String)` directive, and are added to the 
+generated schema. You can either supply a **reason** argument with a string value or not supply one and receive
+a "No longer supported" message when introspected:
+
+```graphql
+enum Episode @doc(d: "One of the films in the Star Wars Trilogy") {
+    NEWHOPE @doc(d: "Released in 1977"),
+    EMPIRE @doc(d: "Released in 1980"),
+    JEDI @doc(d: "Released in 1983"),
+    FANTOM @doc(d: "Released in 1999") @deprecated(reason: "Not worth referencing"),
+    CLONES @doc(d: "Released in 2002") @deprecated  
 }
 ```

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
@@ -54,6 +54,8 @@ import graphql.schema.TypeResolverProxy
  */
 class SchemaParser private constructor(doc: Document, resolvers: List<GraphQLResolver<*>>, userScalars: List<GraphQLScalarType>, val dictionary: BiMap<String, Class<*>>) {
 
+    val DEFAULT_DEPRECATION_MESSAGE = "No longer supported"
+
     class Builder(
         private val schemaString: StringBuilder = StringBuilder(),
         private val resolvers: MutableList<GraphQLResolver<*>> = mutableListOf(),
@@ -287,7 +289,12 @@ class SchemaParser private constructor(doc: Document, resolvers: List<GraphQLRes
         definition.enumValueDefinitions.forEach { enumDefinition ->
             val enumName = enumDefinition.name
             val enumValue = type.enumConstants.find { it.toString() == enumName } ?: throw SchemaError("Expected value for name '$enumName' in enum '${type.simpleName}' but found none!")
-            builder.value(enumName, enumValue, getDocumentation(enumDefinition.directives))
+            getDeprecated(enumDefinition.directives).let {
+                when (it) {
+                    is String -> builder.value(enumName, enumValue, getDocumentation(enumDefinition.directives), it)
+                    else -> builder.value(enumName, enumValue, getDocumentation(enumDefinition.directives))
+                }
+            }
         }
 
         return builder.build()
@@ -325,6 +332,7 @@ class SchemaParser private constructor(doc: Document, resolvers: List<GraphQLRes
     private fun createFieldDefinition(field: GraphQLFieldDefinition.Builder, fieldDefinition : FieldDefinition): GraphQLFieldDefinition.Builder {
         field.name(fieldDefinition.name)
         field.description(getDocumentation(fieldDefinition.directives))
+        getDeprecated(fieldDefinition.directives)?.let { field.deprecate(it) }
         field.type(determineOutputType(fieldDefinition.type))
         fieldDefinition.inputValueDefinitions.forEach { argumentDefinition ->
             field.argument { argument ->
@@ -353,6 +361,19 @@ class SchemaParser private constructor(doc: Document, resolvers: List<GraphQLRes
             "description".startsWith(it.name) && it.value is StringValue
         }?.value as StringValue?)?.value
     }
+
+    /**
+     * Returns an optional [String] describing a deprecated field/enum.
+     * If a deprecation directive was defined using the @deprecated directive,
+     * then a String containing either the contents of the 'reason' argument, if present, or a default
+     * message defined in [DEFAULT_DEPRECATION_MESSAGE] will be returned. Otherwise, [null] will be returned
+     * indicating no deprecation directive was found within the directives list.
+     */
+    private fun getDeprecated(directives: List<Directive>): String? =
+        getDirective(directives, "deprecated")?.let { directive ->
+            (directive.arguments.find { it.name == "reason" }?.value as? StringValue)?.value ?:
+              DEFAULT_DEPRECATION_MESSAGE
+        }
 
     private fun getDirective(directives: List<Directive>, name: String): Directive? = directives.find {
         it.name == name

--- a/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
@@ -26,8 +26,8 @@ input ItemSearchInput {
 }
 
 input NewItemInput {
-    name: String!
-    type: Type!
+    name: String! @deprecated
+    type: Type! @deprecated(reason: "This is a reason")
 }
 
 enum Type {


### PR DESCRIPTION
@deprecated directive can be used within the schema definition and the messages will now be available when a client introspects the schema for deprecated values. The README.md has also been updated to reflect the new addition.