### PR TITLE
Source class issue

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
@@ -7,7 +7,6 @@ import graphql.language.InputValueDefinition
 import graphql.language.NonNullType
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
-import graphql.schema.GraphQLNonNull
 import java.lang.reflect.Method
 
 class ResolverDataFetcher(val sourceResolver: SourceResolver, method: Method, val args: List<ArgumentPlaceholder>): DataFetcher {
@@ -34,7 +33,7 @@ class ResolverDataFetcher(val sourceResolver: SourceResolver, method: Method, va
                 val expectedType = resolver.dataClassType!! // We've already checked this when setting shouldPassSource
                 args.add({ environment ->
                     val source = environment.source
-                    if (expectedType != source.javaClass) {
+                    if (!(expectedType.isAssignableFrom(source.javaClass))) {
                         throw ResolverError("Source type (${source.javaClass.name}) is not expected type (${expectedType.name})!")
                     }
 

--- a/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
@@ -7,6 +7,7 @@ import graphql.language.InputValueDefinition
 import graphql.language.NonNullType
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLNonNull
 import java.lang.reflect.Method
 
 class ResolverDataFetcher(val sourceResolver: SourceResolver, method: Method, val args: List<ArgumentPlaceholder>): DataFetcher {
@@ -33,7 +34,7 @@ class ResolverDataFetcher(val sourceResolver: SourceResolver, method: Method, va
                 val expectedType = resolver.dataClassType!! // We've already checked this when setting shouldPassSource
                 args.add({ environment ->
                     val source = environment.source
-                    if (!(expectedType.isAssignableFrom(source.javaClass))) {
+                    if (expectedType != source.javaClass) {
                         throw ResolverError("Source type (${source.javaClass.name}) is not expected type (${expectedType.name})!")
                     }
 


### PR DESCRIPTION
Hi,
I ran into an issue with a resolver such as:
public class DataSetResolver  implements GraphQLResolver<DataSet> {
...
}
where I had a number of subclasses of DataSet. I sometimes wanted to work against the generic DataSet and sometime against the more specialized subclasses, as such I had both in the QueryQL schema... The fix below got it working for me.