### PR TITLE
Add subscription support.

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/GraphQLSubscriptionResolver.java
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/GraphQLSubscriptionResolver.java
@@ -1,0 +1,8 @@
+package com.coxautodev.graphql.tools;
+
+public interface GraphQLSubscriptionResolver extends GraphQLRootResolver {
+    @Override
+    default String getResolverName() {
+        return RootTypeInfo.DEFAULT_SUBSCRIPTION_NAME;
+    }
+}

--- a/src/main/kotlin/com/coxautodev/graphql/tools/RootTypeInfo.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/RootTypeInfo.kt
@@ -6,21 +6,25 @@ import graphql.language.TypeName
 /**
  * @author Andrew Potter
  */
-class RootTypeInfo private constructor(val queryType: TypeName?, val mutationType: TypeName?) {
+class RootTypeInfo private constructor(val queryType: TypeName?, val mutationType: TypeName?, val subscriptionType: TypeName?) {
     companion object {
         const val DEFAULT_QUERY_NAME = "Query"
         const val DEFAULT_MUTATION_NAME = "Mutation"
+        const val DEFAULT_SUBSCRIPTION_NAME = "Subscription"
 
         fun fromSchemaDefinitions(definitions: List<SchemaDefinition>): RootTypeInfo {
             val queryType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "query" }?.type as TypeName?
             val mutationType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "mutation" }?.type as TypeName?
+            val subscriptionType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "subscription" }?.type as TypeName?
 
-            return RootTypeInfo(queryType, mutationType)
+            return RootTypeInfo(queryType, mutationType, subscriptionType)
         }
     }
 
     fun getQueryName() = queryType?.name ?: DEFAULT_QUERY_NAME
     fun getMutationName() = mutationType?.name ?: DEFAULT_MUTATION_NAME
+    fun getSubscriptionName() = subscriptionType?.name ?: DEFAULT_SUBSCRIPTION_NAME
 
     fun isMutationRequired() = mutationType != null
+    fun isSubscriptionRequired() = subscriptionType != null
 }

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaObjects.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaObjects.kt
@@ -7,18 +7,19 @@ import graphql.schema.GraphQLType
 /**
  * @author Andrew Potter
  */
-data class SchemaObjects(val query: GraphQLObjectType, val mutation: GraphQLObjectType?, val dictionary: Set<GraphQLType>) {
+data class SchemaObjects(val query: GraphQLObjectType, val mutation: GraphQLObjectType?, val subscription: GraphQLObjectType?, val dictionary: Set<GraphQLType>) {
 
     /**
-     * Makes a GraphQLSchema with query and mutation.
+     * Makes a GraphQLSchema with query, mutation and subscription.
      */
     fun toSchema(): GraphQLSchema = GraphQLSchema.newSchema()
         .query(query)
         .mutation(mutation)
+        .subscription(subscription)
         .build(dictionary)
 
     /**
-     * Makes a GraphQLSchema with query but without mutation.
+     * Makes a GraphQLSchema with query but without mutation and subscription.
      */
     fun toReadOnlySchema(): GraphQLSchema = GraphQLSchema.newSchema()
         .query(query)

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
@@ -67,14 +67,16 @@ class SchemaParser internal constructor(private val dictionary: TypeClassDiction
         interfaces.forEach { (it.typeResolver as TypeResolverProxy).typeResolver = InterfaceTypeResolver(dictionary.inverse(), it, objects) }
         unions.forEach { (it.typeResolver as TypeResolverProxy).typeResolver = UnionTypeResolver(dictionary.inverse(), it, objects) }
 
-        // Find query type and mutation type (if mutation type exists)
+        // Find query type and mutation/subscription type (if mutation/subscription type exists)
         val queryName = rootInfo.getQueryName()
         val mutationName = rootInfo.getMutationName()
+        val subscriptionName = rootInfo.getSubscriptionName()
 
         val query = objects.find { it.name == queryName } ?: throw SchemaError("Expected a Query object with name '$queryName' but found none!")
         val mutation = objects.find { it.name == mutationName } ?: if(rootInfo.isMutationRequired()) throw SchemaError("Expected a Mutation object with name '$mutationName' but found none!") else null
+        val subscription = objects.find { it.name == subscriptionName } ?: if (rootInfo.isSubscriptionRequired()) throw SchemaError("Expected a Subscription object with name '$subscriptionName' but found none!") else null
 
-        return SchemaObjects(query, mutation, (objects + inputObjects + enums + interfaces + unions).toSet())
+        return SchemaObjects(query, mutation, subscription, (objects + inputObjects + enums + interfaces + unions).toSet())
     }
 
     /**

--- a/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
@@ -15,7 +15,7 @@ class EndToEndSpec extends Specification {
     def setupSpec() {
         gql = new GraphQL(SchemaParser.newParser()
             .schemaString(EndToEndSpecKt.schemaDefinition)
-            .resolvers(new Query(), new Mutation(), new ItemResolver())
+            .resolvers(new Query(), new Mutation(), new Subscription(), new ItemResolver())
             .scalars(EndToEndSpecKt.CustomUUIDScalar)
             .dictionary("OtherItem", OtherItemWithWrongName)
             .build()
@@ -60,6 +60,23 @@ class EndToEndSpec extends Specification {
 
         then:
             data.addItem
+    }
+
+    def "generated schema should execute the subscription query"() {
+        when:
+            def newItem = new Item(1, "item", Type.TYPE_1, UUID.randomUUID(), [])
+            def data = Utils.assertNoGraphQlErrors(gql, [:], new OnItemCreatedContext(newItem)) {
+                '''
+                subscription {
+                    onItemCreated {
+                        id
+                    }
+                } 
+                '''
+            }
+
+        then:
+            data.onItemCreated
     }
 
     def "generated schema should handle interface types"() {

--- a/src/test/groovy/com/coxautodev/graphql/tools/Utils.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/Utils.groovy
@@ -11,8 +11,8 @@ import groovy.transform.CompileStatic
 class Utils {
     private static ObjectMapper mapper = new ObjectMapper()
 
-    static Map<String, Object> assertNoGraphQlErrors(GraphQL gql, Map<String, Object> args = [:], Closure<String> closure) {
-        def result = gql.execute(closure(), new Object(), args)
+    static Map<String, Object> assertNoGraphQlErrors(GraphQL gql, Map<String, Object> args = [:], Object context = new Object(), Closure<String> closure) {
+        def result = gql.execute(closure(), context, args)
         if(!result.errors.isEmpty()) {
             throw new AssertionError("GraphQL result contained errors!\n${result.errors.collect { mapper.writeValueAsString(it) }.join("\n")}")
         }

--- a/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
@@ -2,6 +2,7 @@ package com.coxautodev.graphql.tools
 
 import graphql.language.StringValue
 import graphql.schema.Coercing
+import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLScalarType
 import java.util.Optional
 import java.util.UUID
@@ -29,6 +30,10 @@ type Query {
 
 type Mutation {
     addItem(newItem: NewItemInput!): Item!
+}
+
+type Subscription {
+    onItemCreated: Item!
 }
 
 input ItemSearchInput {
@@ -110,6 +115,14 @@ class Mutation: GraphQLMutationResolver {
         return Item(items.size, input.name, input.type, UUID.randomUUID(), listOf()).apply {
             items.add(this)
         }
+    }
+}
+
+class OnItemCreatedContext(val newItem: Item)
+
+class Subscription : GraphQLSubscriptionResolver {
+    fun onItemCreated(env: DataFetchingEnvironment): Item {
+        return env.getContext<OnItemCreatedContext>().newItem
     }
 }
 


### PR DESCRIPTION
graphql-java has some support for executing subscriptions - the "query" you would run when you want to notify your subscribed clients of some event.

This PR just adds subscription as another supported operation.

The subscribing/unsubscribing, transport, etc. are not handled here, those are perhaps concerns for another library.

The test currently just uses the context to pass data about the event that occurred to the resolver, but maybe there's a better (and more type-safe) way to do this.