### PR TITLE
Fix input and ouput type checking

### DIFF
--- a/src/test/groovy/com/coxautodev/graphql/tools/SchemaParserSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/SchemaParserSpec.groovy
@@ -148,7 +148,7 @@ class SchemaParserSpec extends Specification {
 
         then:
             def t = thrown(SchemaError)
-            t.message.contains("Was an object type incorrectly used as an input type")
+            t.message.contains("Was a type only permitted for object types incorrectly used as an input type, or vice-versa")
     }
 }
 


### PR DESCRIPTION
This is a regression from fixing ticket #56. There were 2 bugs:

1) The input and output type validation only checked that GraphQL
objects and inputs were used recursively, but didn't account for other
types like enums, interfaces, and unions. This wasn't captured in the
test suite due to #2 below, but this resulted in a SchemaError if you
used optional enums in input types, or used an optional enum, interface,
or union as an output type.

2) The determine(Input/Output)Type logic asserts against the wrapped
GraphQLType, meaning if you had a list (GraphQLList) or required field
(GraphQLNonNull), it didn't perform the new check since the
GraphQLTypeReference was nested. This is why the existing EndToEnd test
suite continued to pass since it marks almost all parameters that have
enums as required and such.