### PR TITLE
Associate GraphQL ListType with any Iterable in Java

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/TypeClassMatcher.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/TypeClassMatcher.kt
@@ -48,7 +48,7 @@ internal class TypeClassMatcher(private val definitionsByName: Map<String, TypeD
             }
 
             is ListType -> {
-                if(realType is ParameterizedType && potentialMatch.generic.isTypeAssignableFromRawClass(realType, List::class.java)) {
+                if(realType is ParameterizedType && potentialMatch.generic.isTypeAssignableFromRawClass(realType, Iterable::class.java)) {
                     match(potentialMatch, graphQLType.type, realType.actualTypeArguments.first())
                 } else {
                     throw error(potentialMatch, "Java class is not a List: $realType")


### PR DESCRIPTION
GraphQL list type representation is too limited to be mapped only to java.unit.List. Instead we should be able to represent probably any java Iterable type. As a result I'm getting the error for models with Iterables types other than List:
```
class User {
  addresses: Set<Address>
}

type User {
  addresses: [Address]
} 

Exception in thread "main" com.coxautodev.graphql.tools.SchemaClassScannerError: 
Unable to match type definition (ListType{type=TypeName{name='Address'}}) with java type (java.util.Set<Address>): 
Java class is not a List: java.util.Set<Address>
```