### PR TITLE
Support null value in PropertyFieldResolver.

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/PropertyFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PropertyFieldResolver.kt
@@ -21,7 +21,7 @@ internal class PropertyFieldResolver(field: FieldDefinition, search: FieldResolv
 }
 
 class PropertyFieldResolverDataFetcher(private val sourceResolver: SourceResolver, private val field: Field): DataFetcher<Any> {
-    override fun get(environment: DataFetchingEnvironment): Any {
+    override fun get(environment: DataFetchingEnvironment): Any? {
         return field.get(sourceResolver(environment))
     }
 }


### PR DESCRIPTION
MethodFieldResolver already supports null and Optional as the returned values. However, the PropertyFieldResolver does not do the same. Since normally a field should not be declared as Optional, this is the minimal change needed to support null value properly.