### PR TITLE
 changed check if dictionary contains interface type (fixes #97)

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaClassScanner.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaClassScanner.kt
@@ -180,7 +180,7 @@ internal class SchemaClassScanner(initialDictionary: BiMap<String, Class<*>>, al
     private fun getAllObjectTypesImplementingDiscoveredInterfaces(): List<ObjectTypeDefinition> {
         return dictionary.keys.filterIsInstance<InterfaceTypeDefinition>().map { iface ->
             objectDefinitions.filter { obj -> obj.implements.filterIsInstance<TypeName>().any { it.name == iface.name } }
-        }.flatten().distinct()
+        }.flatten().distinctBy{ it.name }
     }
 
     private fun getAllObjectTypeMembersOfDiscoveredUnions(): List<ObjectTypeDefinition> {
@@ -192,7 +192,8 @@ internal class SchemaClassScanner(initialDictionary: BiMap<String, Class<*>>, al
 
     private fun handleInterfaceOrUnionSubTypes(types: List<ObjectTypeDefinition>, failureMessage: (ObjectTypeDefinition) -> String) {
         types.forEach { type ->
-            if(!unvalidatedTypes.contains(type) && !dictionary.containsKey(type)) {
+            val dictionaryContainsType = dictionary.filter{ it.key.name == type.name }.isNotEmpty()
+            if(!unvalidatedTypes.contains(type) && !dictionaryContainsType) {
                 val initialEntry = initialDictionary[type.name] ?: throw SchemaClassScannerError(failureMessage(type))
                 handleFoundType(type, initialEntry.get(), DictionaryReference())
             }

--- a/src/test/groovy/com/coxautodev/graphql/tools/SchemaClassScannerSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/SchemaClassScannerSpec.groovy
@@ -250,7 +250,7 @@ class SchemaClassScannerSpec extends Specification {
         when:
         ScannedSchemaObjects objects = SchemaParser.newParser()
         // uncommenting the line below makes the test succeed
-//                .dictionary(InterfaceImplementation.NamedResourceImpl.class)
+                .dictionary(InterfaceImplementation.NamedResourceImpl.class)
                 .resolvers(new InterfaceImplementation())
                 .schemaString("""
                     type Query {

--- a/src/test/groovy/com/coxautodev/graphql/tools/SchemaClassScannerSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/SchemaClassScannerSpec.groovy
@@ -246,6 +246,44 @@ class SchemaClassScannerSpec extends Specification {
         }
     }
 
+    def "scanner handles interface implementation that is not used as field type"() {
+        when:
+        ScannedSchemaObjects objects = SchemaParser.newParser()
+        // uncommenting the line below makes the test succeed
+//                .dictionary(InterfaceImplementation.NamedResourceImpl.class)
+                .resolvers(new InterfaceImplementation())
+                .schemaString("""
+                    type Query {
+                        query1: NamedResource
+                    }
+
+                    interface NamedResource {
+                        name: String!
+                    }
+
+                    type NamedResourceImpl implements NamedResource {
+                        name: String!
+                    }
+                """)
+                .scan()
+
+        then:
+        objects.definitions.findAll { it instanceof InterfaceTypeDefinition }.size() == 1
+    }
+
+    class InterfaceImplementation implements GraphQLQueryResolver {
+        NamedResource query1() { null }
+        NamedResourceImpl query2() { null }
+
+        static interface NamedResource {
+            String name()
+        }
+
+        static class NamedResourceImpl implements NamedResource {
+            String name() {}
+        }
+    }
+
     def "scanner handles custom scalars when matching input types"() {
         when:
             GraphQLScalarType customMap = new GraphQLScalarType('customMap', '', new Coercing<Map<String, Object>, Map<String, Object>>() {


### PR DESCRIPTION
There's a problem in the `dictionary.containsKey(type)` check which caused the issue. I wasn't able to reproduce it using tests, but this change finally solved the problem for me.