### PR TITLE
Support field resolver methods of the format getField<Name>

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,16 +199,20 @@ First on the resolver or root resolver (note that dataClassInstance doesn't appl
 1. `method <name>(dataClassInstance, *fieldArgs [, DataFetchingEnvironment])`
 2. `method is<Name>(dataClassInstance, *fieldArgs [, DataFetchingEnvironment])`, only if the field returns a `Boolean`
 3. `method get<Name>(dataClassInstance, *fieldArgs [, DataFetchingEnvironment])`
+4. `method getField<Name>(dataClassInstance, *fieldArgs [, DataFetchingEnvironment])`
 
 Then on the data class:
 1. `method <name>(*fieldArgs [, DataFetchingEnvironment])`
 2. `method is<Name>(*fieldArgs [, DataFetchingEnvironment])`, only if the field returns a `Boolean`
 3. `method get<Name>(*fieldArgs [, DataFetchingEnvironment])`
-4. `field <name>`
+4. `method getField<Name>(*fieldArgs [, DataFetchingEnvironment])`
+5. `field <name>`
 
 *Note:* All reflection discovery is done on startup, and runtime reflection method calls use [reflectasm](https://github.com/EsotericSoftware/reflectasm), which increases performance and unifies stacktraces.  No more `InvocationTargetException`!
 
 *Note:* `java.util.Optional` can be used for nullable field arguments and nullable return values, and the schema parser will verify that it's not used with non-null field arguments and return values.
+
+*Note:* Methods on `java.lang.Object` are excluded from method matching, for example a field named `class` will require a method named `getFieldClass` defined.
 
 ### Enum Types
 

--- a/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
@@ -51,6 +51,14 @@ type Query {
 
     complexInputType(complexInput: [[ComplexInputType!]]): String!
     extendedType: ExtendedType!
+
+    # Exercise field with get<<capitalised field name>> resolver
+    itemsWithGetResolver: [Item!]
+
+    # Check it's possible to use field names that correspond to methods on the java.lang.Object class
+    class: [Item!]
+    hashCode: [Item!]
+
     propertyField: String!
 }
 
@@ -177,6 +185,11 @@ class Query: GraphQLQueryResolver, ListListResolver<String>() {
 
     fun complexInputType(input: List<List<ComplexInputType>?>?) = input?.firstOrNull()?.firstOrNull()?.let { it.first == "foo" && it.second?.firstOrNull()?.firstOrNull()?.first == "bar" } ?: false
     fun extendedType() = ExtendedType()
+
+    fun getItemsWithGetResolver() = items
+
+    fun getFieldClass() = items
+    fun getFieldHashCode() = items
 
     private val propertyField = "test"
 }


### PR DESCRIPTION
A proposal for allowing field resolvers that match method names that are reserved or already exist on `java.lang.Object`, e.g `class`, `hashCode` etc.

