### PR TITLE
Support for Javassist proxies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Optional for supporting Javassist proxies -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.22.0-GA</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/src/main/kotlin/com/coxautodev/graphql/tools/JavassistProxyHandler.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/JavassistProxyHandler.kt
@@ -1,0 +1,25 @@
+package com.coxautodev.graphql.tools
+
+import javassist.util.proxy.ProxyFactory
+
+
+/**
+ * @author Marcus Thiesen
+ */
+
+class JavassistProxyHandler : ProxyHandler {
+
+    val isEnabled: Boolean =
+            try {
+                Class.forName("javassist.util.proxy.ProxyFactory")
+                true
+            } catch (_: ClassNotFoundException) {
+                false
+            }
+
+    override fun canHandle(resolver: GraphQLResolver<*>?): Boolean {
+        return isEnabled && ProxyFactory.isProxyClass(resolver?.javaClass)
+    }
+
+    override fun getTargetClass(resolver: GraphQLResolver<*>?): Class<*> = resolver!!.javaClass!!.superclass
+}

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
@@ -234,7 +234,7 @@ data class SchemaParserOptions internal constructor(val genericWrappers: List<Ge
         private var useDefaultGenericWrappers = true
         private var allowUnimplementedResolvers = false
         private var objectMapperConfigurer: ObjectMapperConfigurer = ObjectMapperConfigurer { _, _ ->  }
-        private val proxyHandlers: MutableList<ProxyHandler> = mutableListOf(Spring4AopProxyHandler(), GuiceAopProxyHandler())
+        private val proxyHandlers: MutableList<ProxyHandler> = mutableListOf(Spring4AopProxyHandler(), GuiceAopProxyHandler(), JavassistProxyHandler())
 
         fun genericWrappers(genericWrappers: List<GenericWrapper>) = this.apply {
             this.genericWrappers.addAll(genericWrappers)


### PR DESCRIPTION
HK2 creates Javassist based proxies when you do AOP, so this is needed to
support them.

Basically a variation of #107

I'm not a Kotlin guy, but I am wondering how the whole class resolving here works? Because I did the same thing as in the `Spring4AopProxyHandler` which has an `import` on `org.springframework.aop.support.AopUtils`. In the Java world that would make the class unloadable in case these dependencies are not there, but apparently for Kotlin that works?