### PR TITLE
Add `MultiResolverInfo` implementation

### DIFF
--- a/src/test/groovy/com/coxautodev/graphql/tools/SchemaParserSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/SchemaParserSpec.groovy
@@ -79,6 +79,35 @@ class SchemaParserSpec extends Specification {
             noExceptionThrown()
     }
 
+    def "parser should parse correctly when multiple query resolvers are given"() {
+        when:
+            SchemaParser.newParser()
+                .schemaString('''
+                    type Obj {
+                        name: String
+                    }
+
+                    type AnotherObj {
+                        key: String
+                    }
+
+                    type Query {
+                        obj: Obj
+                        anotherObj: AnotherObj
+                    }
+                ''')
+                .resolvers(new GraphQLQueryResolver() {
+                    Obj getObj() { return new Obj() }
+                }, new GraphQLQueryResolver() {
+                    AnotherObj getAnotherObj() { return new AnotherObj() }
+                })
+                .build()
+                .makeExecutableSchema()
+
+        then:
+            noExceptionThrown()
+    }
+
     def "parser should parse correctly when multiple resolvers for the same data type are given"() {
         when:
             SchemaParser.newParser()

--- a/src/test/groovy/com/coxautodev/graphql/tools/SchemaParserSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/SchemaParserSpec.groovy
@@ -79,6 +79,41 @@ class SchemaParserSpec extends Specification {
             noExceptionThrown()
     }
 
+    def "parser should parse correctly when multiple resolvers for the same data type are given"() {
+        when:
+            SchemaParser.newParser()
+                .schemaString('''
+                    type RootObj {
+                        obj: Obj
+                        anotherObj: AnotherObj
+                    }
+                    
+                    type Obj {
+                        name: String
+                    }
+                    
+                    type AnotherObj {
+                        key: String
+                    }
+                    
+                    type Query {
+                        rootObj: RootObj
+                    }
+                ''')
+                .resolvers(new GraphQLQueryResolver() {
+                    RootObj getRootObj() { return new RootObj() }
+                }, new GraphQLResolver<RootObj>() {
+                    Obj getObj(RootObj rootObj) { return new Obj() }
+                }, new GraphQLResolver<RootObj>() {
+                    AnotherObj getAnotherObj(RootObj rootObj) { return new AnotherObj() }
+                })
+                .build()
+                .makeExecutableSchema()
+
+        then:
+            noExceptionThrown()
+    }
+
     def "parser should allow setting custom generic wrappers"() {
         when:
             SchemaParser.newParser()
@@ -196,6 +231,11 @@ class Filter {
 class CustomGenericWrapper<T, V> { }
 class Obj {
     def name() { null }
+}
+class AnotherObj {
+    def key() { null }
+}
+class RootObj {
 }
 
 class ProxiedResolver implements GraphQLQueryResolver {


### PR DESCRIPTION
This resolver adds support for multiple type resolvers related to the
same data type. The `MultiResolverInfo` wraps a list of
`NormalResolverInfo` and checks their data type class. It also overrides
the `getFieldSearches` method to provide a list of `Search` instances
with all resolvers first and a `Search` instance for the data type
class.

`SchemaClassScanner.scanQueueItemForPotentialMatches` now tries to use
`NormalResolverInfo` if there are more then one potential type resolvers
available through the `resolverInfos` field.