### PR TITLE
Fix schema introspection bug for arguments of type list

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
@@ -243,7 +243,7 @@ class SchemaParser internal constructor(scanResult: ScannedSchemaObjects) {
             is StringValue -> value.value
             is EnumValue -> value.name
             is BooleanValue -> value.isValue
-            is ArrayValue -> value.values.map { buildDefaultValue(it) }.toTypedArray()
+            is ArrayValue -> value.values.map { buildDefaultValue(it) }
             is ObjectValue -> value.objectFields.associate { it.name to buildDefaultValue(it.value) }
             else -> throw SchemaError("Unrecognized default value: $value")
         }

--- a/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
@@ -262,6 +262,29 @@ class EndToEndSpec extends Specification {
             data.defaultArgument == true
     }
 
+    def "introspection shouldn't fail for arguments of type list with a default value (defaultEnumListArgument)"() {
+        when:
+            def data = Utils.assertNoGraphQlErrors(gql) {
+                '''
+                {
+                   __type(name: "Query") {
+                       name
+                       fields {
+                         name
+                         args {
+                           name
+                           defaultValue
+                         }
+                       }
+                   }
+                }
+                '''
+            }
+
+        then:
+            data.__type
+    }
+
     def "generated schema should return null without errors for null value with nested fields"() {
         when:
             def data = Utils.assertNoGraphQlErrors(gql) {

--- a/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
@@ -44,6 +44,7 @@ type Query {
     customScalarMapInputType(customScalarMap: customScalarMap): customScalarMap
 
     defaultArgument(arg: Boolean = true): Boolean!
+    defaultEnumListArgument(types: [Type] = [TYPE_1]): [Type]
 
     listList: [[String!]!]!
     futureItems: [Item!]!
@@ -179,6 +180,7 @@ class Query: GraphQLQueryResolver, ListListResolver<String>() {
     fun customScalarMapInputType(customScalarMap: Map<String, Any>) = customScalarMap
 
     fun defaultArgument(arg: Boolean) = arg
+    fun defaultEnumListArgument(types: List<Type>) = types
 
     fun futureItems() = CompletableFuture.completedFuture(items)
     fun complexNullableType(): ComplexNullable? = null


### PR DESCRIPTION
When parsing the schema and building default values, use List instead of Java array, since graphql-java expects an Iterable value for the list type (see AstValueHelper::handleList)

Fixes issue #92 