### PR TITLE
Bump apache-commons to add compatibility with Java 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.6</version>
+            <version>3.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
With the end of support for java 1.9  it's important to keep project working with currently supported version of jdk which is 10.
Unfortunately, apache.commons.lang 3.6 check java version installed in the system, but due to change 
 in the standard of version naming (for java 9 it was "1.9" while for java 10 it's "10") library with version 3.6 fails to resolve "10" as an acceptable version of JVM and thus throws an exception.

In version 3.7 this case was fixed and java 10 is accepted as valid version.