### PR TITLE
Generic wrapper improvement. Pt. II

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
@@ -2,6 +2,7 @@ package com.coxautodev.graphql.tools
 
 import com.google.common.primitives.Primitives
 import org.apache.commons.lang3.reflect.TypeUtils
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 import sun.reflect.generics.reflectiveObjects.WildcardTypeImpl
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.TypeVariable
@@ -88,7 +89,13 @@ open internal class GenericType(protected val mostSpecificType: JavaType, protec
                         throw IndexOutOfBoundsException("Generic type '${TypeUtils.toString(type)}' does not have a type argument at index ${genericType.index}!")
                     }
 
-                    return unwrapGenericType(typeArguments[genericType.index])
+                    val unwrapsTo = if (genericType.wrapTo != null) {
+                        ParameterizedTypeImpl.make(genericType.wrapTo, arrayOf(typeArguments[genericType.index]), null)
+                    } else {
+                        typeArguments[genericType.index]
+                    }
+
+                    return unwrapGenericType(unwrapsTo)
                 }
                 is Class<*> -> if(type.isPrimitive) Primitives.wrap(type) else type
                 is TypeVariable<*> -> {

--- a/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
@@ -2,7 +2,6 @@ package com.coxautodev.graphql.tools
 
 import com.google.common.primitives.Primitives
 import org.apache.commons.lang3.reflect.TypeUtils
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 import sun.reflect.generics.reflectiveObjects.WildcardTypeImpl
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.TypeVariable

--- a/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
@@ -89,8 +89,8 @@ open internal class GenericType(protected val mostSpecificType: JavaType, protec
                         throw IndexOutOfBoundsException("Generic type '${TypeUtils.toString(type)}' does not have a type argument at index ${genericType.index}!")
                     }
 
-                    val unwrapsTo = if (genericType.wrapTo != null) {
-                        ParameterizedTypeImpl.make(genericType.wrapTo, arrayOf(typeArguments[genericType.index]), null)
+                    val unwrapsTo = if (genericType.schemaWrapper != null) {
+                        genericType.schemaWrapper.invoke(typeArguments[genericType.index])
                     } else {
                         typeArguments[genericType.index]
                     }

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
@@ -294,30 +294,30 @@ data class SchemaParserOptions internal constructor(val contextClass: Class<*>?,
         }
     }
 
-    data class GenericWrapper(val type: Class<*>, val index: Int, val transformer: (Any, DataFetchingEnvironment) -> Any?, val wrapTo: Class<*>? = null) {
+    data class GenericWrapper(val type: Class<*>, val index: Int, val transformer: (Any, DataFetchingEnvironment) -> Any?, val schemaWrapper: ((JavaType) -> JavaType)? = null) {
         
         constructor(type: Class<*>, index: Int): this(type, index, { x, _ -> x })
         constructor(type: KClass<*>, index: Int): this(type.java, index, { x, _ -> x })
-        constructor(type: Class<*>, index: Int, wrapTo: Class<*>): this(type, index, { x, _ -> x }, wrapTo)
-        constructor(type: KClass<*>, index: Int, wrapTo: Class<*>): this(type.java, index, { x, _ -> x }, wrapTo)
+        constructor(type: Class<*>, index: Int, schemaWrapper: ((JavaType) -> JavaType)?): this(type, index, { x, _ -> x }, schemaWrapper)
+        constructor(type: KClass<*>, index: Int, schemaWrapper: ((JavaType) -> JavaType)?): this(type.java, index, { x, _ -> x }, schemaWrapper)
 
         companion object {
 
             @Suppress("UNCHECKED_CAST")
-            @JvmStatic fun <T> withTransformer(type: Class<T>, index: Int, transformer: (T, DataFetchingEnvironment) -> Any?, wrapTo: Class<*>? = null): GenericWrapper where T: Any {
-                return GenericWrapper(type, index, transformer as (Any, DataFetchingEnvironment) -> Any?, wrapTo)
+            @JvmStatic fun <T> withTransformer(type: Class<T>, index: Int, transformer: (T, DataFetchingEnvironment) -> Any?, schemaWrapper: ((JavaType) -> JavaType)? = null): GenericWrapper where T: Any {
+                return GenericWrapper(type, index, transformer as (Any, DataFetchingEnvironment) -> Any?, schemaWrapper)
             }
             
-            fun <T> withTransformer(type: KClass<T>, index: Int, transformer: (T, DataFetchingEnvironment) -> Any?, wrapTo: Class<*>? = null): GenericWrapper where T: Any {
-                return withTransformer(type.java, index, transformer, wrapTo)
+            fun <T> withTransformer(type: KClass<T>, index: Int, transformer: (T, DataFetchingEnvironment) -> Any?, schemaWrapper: ((JavaType) -> JavaType)? = null): GenericWrapper where T: Any {
+                return withTransformer(type.java, index, transformer, schemaWrapper)
             }
 
-            @JvmStatic fun <T> withTransformer(type: Class<T>, index: Int, transformer: (T) -> Any?, wrapTo: Class<*>? = null): GenericWrapper where T: Any {
-                return withTransformer(type, index, { x, _ -> transformer.invoke(x) }, wrapTo)
+            @JvmStatic fun <T> withTransformer(type: Class<T>, index: Int, transformer: (T) -> Any?, schemaWrapper: ((JavaType) -> JavaType)? = null): GenericWrapper where T: Any {
+                return withTransformer(type, index, { x, _ -> transformer.invoke(x) }, schemaWrapper)
             }
 
-            fun <T> withTransformer(type: KClass<T>, index: Int, transformer: (T) -> Any?, wrapTo: Class<*>? = null): GenericWrapper where T: Any {
-                return withTransformer(type.java, index, transformer, wrapTo)
+            fun <T> withTransformer(type: KClass<T>, index: Int, transformer: (T) -> Any?, schemaWrapper: ((JavaType) -> JavaType)? = null): GenericWrapper where T: Any {
+                return withTransformer(type.java, index, transformer, schemaWrapper)
             }
             
         }

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.BiMap
 import com.google.common.collect.HashBiMap
 import com.google.common.collect.Maps
-import com.google.common.util.concurrent.ListenableFuture
 import graphql.parser.Parser
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLScalarType
@@ -12,11 +11,9 @@ import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.reactivestreams.Publisher
 import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
-import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.Future
-import java.util.stream.Stream
 import kotlin.reflect.KClass
 
 /**

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
@@ -363,18 +363,6 @@ data class SchemaParserOptions internal constructor(val contextClass: Class<*>?,
             ): GenericWrapper where T: Any {
                 return listCollectionWithTransformer(type.java, index, transformer)
             }
-
-            @JvmStatic fun <T>  listCollection(type: Class<T>, index: Int): GenericWrapper where T: Any {
-                return listCollectionWithTransformer(
-                    type,
-                    index,
-                    { x -> x }
-                )
-            }
-
-            fun listCollection(type: KClass<*>, index: Int): GenericWrapper {
-                return listCollection(type.java, index)
-            }
         }
         
     }

--- a/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
@@ -8,7 +8,6 @@ import graphql.language.TypeDefinition
 import graphql.language.TypeName
 import spock.lang.Specification
 import spock.lang.Unroll
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future

--- a/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
@@ -8,6 +8,7 @@ import graphql.language.TypeDefinition
 import graphql.language.TypeName
 import spock.lang.Specification
 import spock.lang.Unroll
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
@@ -29,7 +30,11 @@ class TypeClassMatcherSpec extends Specification {
         new SchemaParserOptions.GenericWrapper(
             GenericCustomListType.class,
             0,
-            List.class
+            { type -> ParameterizedTypeImpl.make(
+                List.class,
+                [type] as java.lang.reflect.Type[],
+                null
+            )}
         )
     ).build()
     private static final FieldResolverScanner scanner = new FieldResolverScanner(options)

--- a/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
@@ -27,9 +27,10 @@ class TypeClassMatcherSpec extends Specification {
             GenericCustomType.class,
             0
         ),
-        SchemaParserOptions.GenericWrapper.listCollection(
+        SchemaParserOptions.GenericWrapper.listCollectionWithTransformer(
             GenericCustomListType.class,
-            0
+            0,
+            { x -> x }
         )
     ).build()
     private static final FieldResolverScanner scanner = new FieldResolverScanner(options)

--- a/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/TypeClassMatcherSpec.groovy
@@ -27,14 +27,9 @@ class TypeClassMatcherSpec extends Specification {
             GenericCustomType.class,
             0
         ),
-        new SchemaParserOptions.GenericWrapper(
+        SchemaParserOptions.GenericWrapper.listCollection(
             GenericCustomListType.class,
-            0,
-            { type -> ParameterizedTypeImpl.make(
-                List.class,
-                [type] as java.lang.reflect.Type[],
-                null
-            )}
+            0
         )
     ).build()
     private static final FieldResolverScanner scanner = new FieldResolverScanner(options)


### PR DESCRIPTION
## This PR continues effort of easy integration with Reactor https://github.com/graphql-java/graphql-java-tools/issues/103
As noted by @sp00m in https://github.com/graphql-java/graphql-java-tools/pull/120 the PR only solved issue of single-value generics, eg `Mono<T> -> Future<T>`. Flat transformations of list-like generics, eg `Flux<T>`, still had issues due to unwrapping strategy of `GenericType`.

This PR adds `schemaWrapper` parameter which allows flat transformations for generics. Though this PR directly addresses `Flux<T> -> List<T>` transformation it could potentially solve more complex issues for other types as well.

The solution for `Flux<T> -> List<T>` transformation problem using this PR would be to register new `GenericWrapper`
```
SchemaParserOptions.GenericWrapper.listCollectionWithTransformer(
    Flux::class.java,
    0,
    { flux -> flux.collectList().toFuture() }
)
```

If you check commit https://github.com/graphql-java/graphql-java-tools/pull/155/commits/6825b8c59746fd7593cb0df45159579e93b6788e initially I tried to apply another wrap-to-list approach, however the one in this PR looks much more generic.