### PR TITLE
Make interface default methods available as field resolver methods.

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/FieldResolverScanner.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/FieldResolverScanner.kt
@@ -21,8 +21,8 @@ internal class FieldResolverScanner(val options: SchemaParserOptions) {
         private val log = LoggerFactory.getLogger(FieldResolverScanner::class.java)
 
         fun getAllMethods(type: Class<*>) =
-            type.declaredMethods.toList().filter { !it.isSynthetic } + ClassUtils.getAllSuperclasses(type)
-                    .flatMap { it.declaredMethods.toList() }
+                (type.methods.toList() + ClassUtils.getAllSuperclasses(type).flatMap { it.methods.toList() })
+                    .filter { !it.isSynthetic }
                     .filter { !Modifier.isPrivate(it.modifiers) }
                     // discard any methods that are coming off the root of the class hierarchy
                     // to avoid issues with duplicate method declarations


### PR DESCRIPTION
We use default interface methods to implement some of the shared functionality between types. This change pulls all of the methods from the class and super class instead of just declared methods.

I also moved the filters for private/synthetic/Object to cover both the passed type and the super types. 
