### PR TITLE
Introduce PerFieldObjectMapperProvider

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
@@ -38,9 +38,7 @@ internal class MethodFieldResolver(field: FieldDefinition, search: FieldResolver
     override fun createDataFetcher(): DataFetcher<*> {
         val batched = isBatched(method, search)
         val args = mutableListOf<ArgumentPlaceholder>()
-        val mapper = ObjectMapper().apply {
-            options.objectMapperConfigurer.configure(this, ObjectMapperConfigurerContext(field))
-        }.registerModule(Jdk8Module()).registerKotlinModule()
+        val mapper = options.objectMapperProvider.provide(field)
 
         // Add source argument if this is a resolver (but not a root resolver)
         if(this.search.requiredFirstParameterType != null) {

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PerFieldConfiguringObjectMapperProvider.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PerFieldConfiguringObjectMapperProvider.kt
@@ -1,0 +1,16 @@
+package com.coxautodev.graphql.tools
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import graphql.language.FieldDefinition
+
+class PerFieldConfiguringObjectMapperProvider(
+		private val objectMapperConfigurer: ObjectMapperConfigurer = ObjectMapperConfigurer { _, _ -> }) : PerFieldObjectMapperProvider {
+
+	override fun provide(fieldDefinition: FieldDefinition): ObjectMapper {
+		return ObjectMapper().apply {
+			objectMapperConfigurer.configure(this, ObjectMapperConfigurerContext(fieldDefinition))
+		}.registerModule(Jdk8Module()).registerKotlinModule()
+	}
+}

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PerFieldObjectMapperProvider.java
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PerFieldObjectMapperProvider.java
@@ -1,0 +1,9 @@
+package com.coxautodev.graphql.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.language.FieldDefinition;
+
+
+public interface PerFieldObjectMapperProvider {
+	ObjectMapper provide(FieldDefinition fieldDefinition);
+}


### PR DESCRIPTION
- Move the default initialisation of the ObjectMapper behind a provider
- By default still use an ObjectMapperConfigurer  based provider